### PR TITLE
Bump ecto version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,7 @@ defmodule Kalecto.Mixfile do
 
   defp deps do
     [
-      {:ecto, "~> 0.9.0 or ~> 0.10.1"},
+      {:ecto, "~> 0.9.0 or >= 0.10.1"},
       {:kalends, "~> 0.6.2"},
 
       {:earmark, "~> 0.1", only: :dev},


### PR DESCRIPTION
First, thanks so much for this library. Coming from Python/pytz/Django, I'm grateful to have the same functionality. 

The current version of Ecto is 0.11.2 so I've changed the dependency spec. Please let me know if it should be different.

By the way, it seems like this should be built into Elixir/Ecto but perhaps there are good reasons why it isn't.
