### PR TITLE
Add map casting

### DIFF
--- a/lib/calecto/date.ex
+++ b/lib/calecto/date.ex
@@ -25,6 +25,8 @@ defmodule Calecto.Date do
     do: from_parts(to_i(year), to_i(month), to_i(day))
   def cast(%Calendar.Date{} = d),
     do: {:ok, d}
+  def cast(%{"year" => year, "month" => month, "day" => day}),
+    do: from_parts(to_i(year), to_i(month), to_i(day))
   def cast(_),
     do: :error
 

--- a/lib/calecto/time.ex
+++ b/lib/calecto/time.ex
@@ -30,6 +30,10 @@ defmodule Calecto.Time do
   end
   def cast(%Calendar.Time{} = t),
     do: {:ok, t}
+  def cast(%{"hour" => hour, "min" => min, "sec" => sec}),
+    do: from_parts(to_i(hour), to_i(min), to_i(sec))
+  def cast(%{"hour" => hour, "min" => min}),
+    do: from_parts(to_i(hour), to_i(min), to_i(0))
   def cast(_),
     do: :error
 


### PR DESCRIPTION
I'm using this nice library with the phoenixframework. Everything works fine except the form saving. I'm using the `Phoenix.HTML` form tags. There are three functions for create date and time selections: 
- [time_select/3](https://hexdocs.pm/phoenix_html/Phoenix.HTML.Form.html#time_select/3)
- [date_select/3](https://hexdocs.pm/phoenix_html/Phoenix.HTML.Form.html#datetime_select/3)
- [datetime_select/3](https://hexdocs.pm/phoenix_html/Phoenix.HTML.Form.html#datetime_select/3)

The values will be send in forms of Maps. So I get the message "_Invalid input for field date._". The cast failed.

**Date**
`%{"day" => "29", "month" => "7", "year" => "2015"}`
**Time (without seconds)**
`%{"hour" => "10", "min" => "42"}`
**Time (with seconds)**
`%{"hour" => "10", "min" => "42", "sec" => "53"}`
**DateTime**
`%{"day" => "29", "hour" => "10", "min" => "42", "month" => "7", "year" => "2015"}`

In the following commit I added map casting for `Calecto.Date` and `Calecto.Time`.
For the `Calecto.DateTime` module the timezone is missing. I haven't a solution yet for this.
