### PR TITLE
Complete tests

### DIFF
--- a/lib/calecto/date.ex
+++ b/lib/calecto/date.ex
@@ -21,7 +21,7 @@ defmodule Calecto.Date do
   @doc """
   Casts to date.
   """
-  def cast(<<year::32, ?-, month::16, ?-, day::16>>),
+  def cast(<<year::4-bytes, ?-, month::2-bytes, ?-, day::2-bytes>>),
     do: from_parts(to_i(year), to_i(month), to_i(day))
   def cast(%Calendar.Date{} = d),
     do: {:ok, d}

--- a/lib/calecto/time.ex
+++ b/lib/calecto/time.ex
@@ -50,4 +50,8 @@ defmodule Calecto.Time do
   def load({hour, min, sec}) do
     Calendar.Time.from_erl({hour, min, sec})
   end
+
+  def load({hour, min, sec, usec}) do
+    Calendar.Time.from_erl({hour, min, sec}, usec)
+  end
 end

--- a/lib/calecto/time.ex
+++ b/lib/calecto/time.ex
@@ -30,6 +30,10 @@ defmodule Calecto.Time do
   end
   def cast(%Calendar.Time{} = t),
     do: {:ok, t}
+  def cast(%{"hour" => hour, "min" => min, "sec" => sec}),
+    do: from_parts(to_i(hour), to_i(min), to_i(sec))
+  def cast(%{"hour" => hour, "min" => min}),
+    do: from_parts(to_i(hour), to_i(min), to_i(0))
   def cast(_),
     do: :error
 
@@ -38,14 +42,16 @@ defmodule Calecto.Time do
   end
 
   @doc """
-  Converts an `Ecto.Time` into a time triplet.
+  Converts an `Ecto.Time` into a time tuple.
   """
   def dump(%Calendar.Time{} = time) do
-    {:ok, Calendar.Time.to_erl(time)}
+    # TODO: Use Calendar.Time.to_micro_erl/1 if exists
+    # {:ok, Calendar.Time.to_micro_erl(time)}
+    {:ok, {time.hour, time.min, time.sec, (if time.usec, do: time.usec, else: 0)}}
   end
 
   @doc """
-  Converts a time triplet into an `Ecto.Time`.
+  Converts a time tuple into an `Ecto.Time`.
   """
   def load({hour, min, sec}) do
     Calendar.Time.from_erl({hour, min, sec})

--- a/test/date_test.exs
+++ b/test/date_test.exs
@@ -1,0 +1,24 @@
+
+defmodule DateTest do
+  use ExUnit.Case
+
+  @date %Calendar.Date{day: 29, month: 7, year: 2015}
+  @string_date "2015-07-29"
+  # @map_date %{"day" => "29", "month" => "7", "year" => "2015"}
+  @tuple_date {2015, 7, 29}
+
+
+  test "dump Date" do
+    assert Calecto.Date.dump(@date) == {:ok, @tuple_date}
+  end
+
+  test "load Date" do
+    assert Calecto.Date.load(@tuple_date) == {:ok, @date}
+  end
+
+  test "cast Date" do
+    assert Calecto.Date.cast(@date) == {:ok, @date}
+    assert Calecto.Date.cast(@string_date) == {:ok, @date}
+    # assert Calecto.Date.cast(@map_date) == {:ok, @date}
+  end
+end

--- a/test/time_test.exs
+++ b/test/time_test.exs
@@ -2,14 +2,14 @@
 defmodule TimeTest do
   use ExUnit.Case
 
-  @time %Calendar.Time{hour: 10, min: 42, sec: 53}
+  @time %Calendar.Time{hour: 10, min: 42, sec: 53, usec: 0}
   @time_with_usec %Calendar.Time{hour: 10, min: 42, sec: 53, usec: 12}
-  @time_without_sec %Calendar.Time{hour: 10, min: 42, sec: 0}
+  @time_without_sec %Calendar.Time{hour: 10, min: 42, sec: 0, usec: 0}
   # @map_time %{"hour" => "10", "min" => "42", "sec" => "53"}
   # @map_time_without_sec %{"hour" => "10", "min" => "42"}
-  @tuple_time {10, 42, 53}
+  @tuple_time {10, 42, 53, 0}
   @tuple_time_with_usec {10, 42, 53, 12}
-  @tuple_time_without_sec {10, 42, 0}
+  @tuple_time_without_sec {10, 42, 0, 0}
 
   test "dump Time" do
     assert Calecto.Time.dump(@time) == {:ok, @tuple_time}

--- a/test/time_test.exs
+++ b/test/time_test.exs
@@ -1,0 +1,29 @@
+
+defmodule TimeTest do
+  use ExUnit.Case
+
+  @time %Calendar.Time{hour: 10, min: 42, sec: 53}
+  @time_with_usec %Calendar.Time{hour: 10, min: 42, sec: 53, usec: 12}
+  @time_without_sec %Calendar.Time{hour: 10, min: 42, sec: 0}
+  # @map_time %{"hour" => "10", "min" => "42", "sec" => "53"}
+  # @map_time_without_sec %{"hour" => "10", "min" => "42"}
+  @tuple_time {10, 42, 53}
+  @tuple_time_with_usec {10, 42, 53, 12}
+  @tuple_time_without_sec {10, 42, 0}
+
+  test "dump Time" do
+    assert Calecto.Time.dump(@time) == {:ok, @tuple_time}
+    assert Calecto.Time.dump(@time_without_sec) == {:ok, @tuple_time_without_sec}
+  end
+
+  test "load Time" do
+    assert Calecto.Time.load(@tuple_time) == {:ok, @time}
+    assert Calecto.Time.load(@tuple_time_with_usec) == {:ok, @time_with_usec}
+  end
+
+  test "cast Time" do
+    assert Calecto.Time.cast(@time) == {:ok, @time}
+    # assert Calecto.Time.cast(@map_time) == {:ok, @time}
+    # assert Calecto.Time.cast(@map_time_without_sec) == {:ok, @time_without_sec}
+  end
+end


### PR DESCRIPTION
Complete tests. 

Fix found complications:
1. String casting on `Date` doesn't work for me, I added the -byte info.
2. On the PhoenixFramework the `Time.load/1` function give me an error. The time is loading with a tuple with 4 parts, so I added usec. (see: [Ecto.Time.load/1](https://github.com/elixir-lang/ecto/blob/v0.14.3/lib/ecto/datetime.ex#L221)).
Same on dump/1, we need a ouple with 4 numbers. On `DateTime` this methods already used.
