### PR TITLE
Allow casting tuple date

### DIFF
--- a/lib/calecto/date.ex
+++ b/lib/calecto/date.ex
@@ -25,7 +25,9 @@ defmodule Calecto.Date do
     do: from_parts(to_i(year), to_i(month), to_i(day))
   def cast(%Calendar.Date{} = d),
     do: {:ok, d}
-   def cast(%{"year" => year, "month" => month, "day" => day}),
+  def cast(%{"year" => year, "month" => month, "day" => day}),
+    do: from_parts(to_i(year), to_i(month), to_i(day))
+  def cast({year, month, day}),
     do: from_parts(to_i(year), to_i(month), to_i(day))
   def cast(_),
     do: :error

--- a/test/date_test.exs
+++ b/test/date_test.exs
@@ -19,5 +19,6 @@ defmodule DateTest do
     assert Calecto.Date.cast(@date) == {:ok, @date}
     assert Calecto.Date.cast(@string_date) == {:ok, @date}
     assert Calecto.Date.cast(@map_date) == {:ok, @date}
+    assert Calecto.Date.cast(@tuple_date) == {:ok, @date}
   end
 end


### PR DESCRIPTION
With the latest changes to Ecto I could not get it is allow querying by a date in any format. It appears that it has started using Postgrex(or other adapter lib) to do some part of the casting for caching. The only way I could easily get queries by a date to work was to add this to Calecto and query by the tuple date.

I'm open to a better way to fix this, but this isn't bad to have regardless.
