### PR TITLE
Add support for Ecto 2.0 beta

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,7 @@ defmodule Calecto.Mixfile do
 
   defp deps do
     [
-      {:ecto, "~> 1.1.3"},
+      {:ecto, "~> 1.1.3 or ~> 2.0-beta"},
       {:calendar, "~> 0.12.3"},
 
       {:earmark, "~> 0.2.1", only: :dev},


### PR DESCRIPTION
"Official" guide is out so it's nice being to able to try it with Calecto: http://blog.plataformatec.com.br/2016/02/ecto-2-0-0-beta-0-is-out/

I ran the tests with 2.0-beta and didn't get any failures.
