### PR TITLE
Remove blank?/1 from all custom Ecto types

### DIFF
--- a/lib/calecto/date.ex
+++ b/lib/calecto/date.ex
@@ -13,11 +13,6 @@ defmodule Calecto.Date do
   def type, do: :date
 
   @doc """
-  Dates are blank when given as strings and the string is blank.
-  """
-  defdelegate blank?(value), to: Ecto.Type
-
-  @doc """
   Casts to date.
   """
   def cast(<<year::4-bytes, ?-, month::2-bytes, ?-, day::2-bytes>>),

--- a/lib/calecto/date_time.ex
+++ b/lib/calecto/date_time.ex
@@ -16,11 +16,6 @@ defmodule Calecto.DateTime do
   def type, do: :calendar_datetime
 
   @doc """
-  Datetimes are blank when given as strings and the string is blank.
-  """
-  defdelegate blank?(value), to: Ecto.Type
-
-  @doc """
   Cast DateTime
   """
   def cast(%DateTime{} = dt), do: {:ok, dt}

--- a/lib/calecto/date_time_utc.ex
+++ b/lib/calecto/date_time_utc.ex
@@ -14,11 +14,6 @@ defmodule Calecto.DateTimeUTC do
   def type, do: :datetime
 
   @doc """
-  Datetimes are blank when given as strings and the string is blank.
-  """
-  defdelegate blank?(value), to: Ecto.Type
-
-  @doc """
   Casts to datetime.
   """
   def cast(<<year::4-bytes, ?-, month::2-bytes, ?-, day::2-bytes, sep,

--- a/lib/calecto/naive_date_time.ex
+++ b/lib/calecto/naive_date_time.ex
@@ -14,11 +14,6 @@ defmodule Calecto.NaiveDateTime do
   def type, do: :datetime
 
   @doc """
-  Datetimes are blank when given as strings and the string is blank.
-  """
-  defdelegate blank?(value), to: Ecto.Type
-
-  @doc """
   Casts to datetime.
   """
   def cast(<<year::4-bytes, ?-, month::2-bytes, ?-, day::2-bytes, sep,

--- a/lib/calecto/time.ex
+++ b/lib/calecto/time.ex
@@ -14,11 +14,6 @@ defmodule Calecto.Time do
   def type, do: :time
 
   @doc """
-  Times are blank when given as strings and the string is blank.
-  """
-  defdelegate blank?(value), to: Ecto.Type
-
-  @doc """
   Casts to time.
   """
   def cast(<<hour::2-bytes, ?:, min::2-bytes, ?:, sec::2-bytes, rest::binary>>) do


### PR DESCRIPTION
`blank?/1` was removed from the Ecto.Type behaviour in Ecto 0.9. Delegating to this function was causing compile warnings on later Ecto versions.

This is a fix for #25.
