### PR TITLE
Try to add iso parsing feature to DateTime

### DIFF
--- a/lib/calecto/date_time.ex
+++ b/lib/calecto/date_time.ex
@@ -49,6 +49,9 @@ defmodule Calecto.DateTime do
     cast(%{"year"=>year, "month"=>month, "day"=>day, "hour"=>hour, "min"=>min,
            "sec"=> 0, "timezone" => timezone})
   end
+  def cast(datetime) when is_binary(datetime) do
+    datetime |> Calendar.DateTime.Parse.rfc3339("Europe/Paris")
+  end
 
   def cast!(datetime) do
     {:ok, dt} = cast(datetime)

--- a/test/date_time_test.exs
+++ b/test/date_time_test.exs
@@ -50,4 +50,8 @@ defmodule DateTimeTest do
                                  "hour" => "99", "min" => "2",
                                  "timezone" => "Europe/Stockholm"}) == {:error, :invalid_datetime}
   end
+
+  test "cast iso datetime" do
+    assert Calecto.DateTime.cast("2018-11-13T13:00:00.000000+01:00")
+  end
 end


### PR DESCRIPTION
I started using your library but I had to add an iso parsing feature to it.
Implementing it I figured why it is not implemented : we have no knowledge of the datetime we get just its offset.
Thus I created this PR not for it be merged right now but to see if anyone could come up with a nice way to pass along the timezone to the parse function (which we could get from another field in an ecto changeset for example).
Thank you for considering the feature ;)